### PR TITLE
make Docs responsive on mobile (fixes #57)

### DIFF
--- a/themes/aframe/layout/layout.ejs
+++ b/themes/aframe/layout/layout.ejs
@@ -19,6 +19,9 @@
     <%- partial('partials/ga') %>
   </head>
   <body data-page-layout="<%- page.layout %>" data-page-type="<%- page.type %>" data-is-home="<%- isHome %>">
+    <% if (!isHome) { %>
+      <%- partial('partials/secondary/mobile_nav') %>
+    <% } %>
     <main id="main" class="main">
       <%- body %>
     </main>

--- a/themes/aframe/layout/partials/secondary/mobile_nav.ejs
+++ b/themes/aframe/layout/partials/secondary/mobile_nav.ejs
@@ -1,0 +1,8 @@
+<aside class="sidebar sidebar-mobile borderless-links c">
+  <header id="header" class="header">
+    <a href="#secondary-nav" class="mobile-nav-btn">Nav</a>
+    <a id="logo" class="logo" href="<%- url_for(config.root) %>">
+      <span class="logo__wordmark"><%- config.title %></span>
+    </a>
+  </header>
+</aside>

--- a/themes/aframe/layout/partials/secondary/sidebar_header.ejs
+++ b/themes/aframe/layout/partials/secondary/sidebar_header.ejs
@@ -56,14 +56,16 @@ links = links.map(function (link) {
 
 %>
 
-<header id="header" class="header">
-  <a id="logo" class="logo" href="<%- url_for(config.root) %>">
-    <span class="logo__wordmark"><%- config.title %></span>
-  </a>
+<div id="secondary-nav" class="secondary-nav">
+  <header id="header" class="header">
+    <a id="logo" class="logo" href="<%- url_for(config.root) %>">
+      <span class="logo__wordmark"><%- config.title %></span>
+    </a>
+  </header>
 
   <ul id="nav" class="nav">
     <% links.forEach(function (link) { %>
       <li class="nav-item"><a href="<%- url_for(link.url) %>" class="nav-link nav-link-docs<%- link.current ? ' current' : '' %>"<%- link.external ? ' target="blank" rel="external"' : '' %>><span><%- link.title %></span></a></li>
     <% }) %>
   </ul>
-</header>
+</div>

--- a/themes/aframe/source/css/_common.styl
+++ b/themes/aframe/source/css/_common.styl
@@ -172,3 +172,11 @@ p
     clear both
     content ""
     display table
+
+@media screen and (max-width: 800px)
+    .sidebar__wrap,
+    .copy__wrap
+        padding 20px
+
+    .logo__wordmark
+        margin-bottom 20px

--- a/themes/aframe/source/css/examples.styl
+++ b/themes/aframe/source/css/examples.styl
@@ -156,7 +156,6 @@ ul
 // Use this version if adding to right block
 .credits
     background url(../images/mozvr-white.svg) 45% 60% no-repeat
-    // background-color yellow
     background-size 80% 80%
     position absolute
     bottom 0

--- a/themes/aframe/source/css/secondary.styl
+++ b/themes/aframe/source/css/secondary.styl
@@ -8,15 +8,16 @@ a
         border-bottom-color rgba(53,196,232,0.75)
         color hsl(192, 80%, 56%)
 
-.header
+.nav
+    border-top 1px dashed rgba(0,0,0,0.1)
     border-bottom 1px dashed rgba(0,0,0,0.1)
-    margin-bottom 20px
-    padding-bottom 20px
+    margin-bottom 30px
+    padding 30px 0
 
 .nav-link
     color rgba(0,0,0,0.35)
     display block
-    padding 5px 0
+    padding 0.25rem 0
     transition 0.1s color ease-in
     &:hover
         color rgba(0,0,0,0.75)
@@ -362,7 +363,67 @@ p [href*=github][href*="/blob/"]:only-child,
             &:before
                 color #aaa
 
+.sidebar-mobile
+    display none
+
 @media screen and (max-width: 800px)
+    .sidebar
+        order 1  // Move to bottom
+        padding 0
+        width 100%
+
+        .list
+            padding 20px
+
+        .nav
+            border 0
+            margin-bottom 0
+            padding 20px 0 0
+
+    .secondary-nav
+        background $pink
+        // margin-top -4px  // To line things up when we jump
+        padding 20px
+
+    .logo__wordmark
+        background url(../images/aframe-name-white.svg) 0 50% no-repeat
+        background-size contain
+        height 35px
+        margin-bottom 0
+
+    .sidebar-mobile
+        background $pink
+        display block
+        position relative
+        padding 20px
+
+    .mobile-nav-btn
+        background-color white
+        border 3px solid white
+        color #000
+        display inline-block
+        float right
+        font 300px 15px $mono-font
+        letter-spacing 0.05rem
+        text-align center
+        transition 0.05s ease-in
+        text-transform uppercase
+        padding 8px 30px
+        &:hover,
+        &:active
+            color #000
+            opacity 0.8
+        &:active
+            background-color rgba(0,0,0,.5)
+
+    .nav-link
+        padding 0.1rem
+        &.current,
+        &.active,
+        &.current:hover,
+        &.active:hover
+            color $white
+
     .main
         flex-direction column
         min-width 100%
@@ -373,3 +434,34 @@ p [href*=github][href*="/blob/"]:only-child,
 
         .github-file-link
             margin-left 0
+
+    .section-title
+        position relative
+        &:before
+            background url(../images/caret.svg) -3px 6px no-repeat
+            background-size 10px auto
+            content ""
+            height 100%
+            left 0
+            pointer-events none
+            position absolute
+            top 0
+            width 10px
+
+    .section-title-active:before
+        transform rotate(90deg)
+        left -6px
+
+    .section-title-inactive + .section-subnav
+        display none
+
+    .section-title-link
+        padding-left 20px
+
+    .subnav-item
+        margin-left 20px
+        margin-right -20px
+
+    .subnav-link
+        margin-left -25px
+        padding-left 35px


### PR DESCRIPTION
it's a decent start, but everything at least fits now and the content is visible without having to scroll past the nav

<img width="1531" alt="screenshot 2015-12-15 21 36 25" src="https://cloud.githubusercontent.com/assets/203725/11833075/07ce50f8-a374-11e5-8392-410559a57c98.png">
<img width="1531" alt="screenshot 2015-12-15 21 36 20" src="https://cloud.githubusercontent.com/assets/203725/11833076/07cf35ea-a374-11e5-9e78-d71e46484f6d.png">
<img width="1531" alt="screenshot 2015-12-15 21 36 14" src="https://cloud.githubusercontent.com/assets/203725/11833073/07cad3ba-a374-11e5-9a36-e85a71fe8fe3.png">
<img width="1531" alt="screenshot 2015-12-15 21 36 00" src="https://cloud.githubusercontent.com/assets/203725/11833074/07cd1ac6-a374-11e5-99d9-28e90b2ed87b.png">
