### PR TITLE
Fix link to complete documentation on lights

### DIFF
--- a/src/docs/guide/cameras-and-lights.md
+++ b/src/docs/guide/cameras-and-lights.md
@@ -39,4 +39,4 @@ The light primitive also comes with several useful properties. There are several
 <a-light type="spot"></a-light>
 ```
 
-The attributes differ based on the type of light used. The full list of light primitive attributes is defined in the [documentation](../docs/).
+The attributes differ based on the type of light used. The full list of light primitive attributes is defined in the [documentation](../components/light.html).


### PR DESCRIPTION
Fixes the link at the bottom of guide/cameras-and-lights.md so that it points to the lights documentation instead of the current 404 page.