### PR TITLE
doc downloader script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 npm-debug.log
 public/
 src/_drafts
+tmp/

--- a/package.json
+++ b/package.json
@@ -18,10 +18,13 @@
     "hexo-server": "^0.1.2",
     "lodash": "^3.10.1",
     "markdown": "^0.5.0",
+    "ncp": "^2.0.0",
+    "node-zip": "^1.1.1",
     "request": "^2.67.0"
   },
   "devDependencies": {
-    "hexo-cli": "^0.1.9"
+    "hexo-cli": "^0.1.9",
+    "unzip": "^0.1.11"
   },
   "hexo": {
     "version": "3.1.1"
@@ -29,6 +32,7 @@
   "scripts": {
     "start": "npm run dev",
     "dev": "npm run clean && npm run server",
+    "docs": "node scripts/docs.js",
     "server": "hexo server",
     "generate": "hexo generate",
     "predeploy": "hexo clean",

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -1,0 +1,25 @@
+var cpdir = require('ncp').ncp;
+var fs = require('fs');
+var request = require('request');
+var unzip = require('unzip');
+
+var BRANCH = process.env.AFRAME_BRANCH || 'master';
+var TARGET = process.env.AFRAME_TARGET || BRANCH;
+var TMP = 'tmp';
+var url = 'https://github.com/aframevr/aframe/archive/' + BRANCH + '.zip';
+
+console.log('Fetching: ' + url);
+request.get({url: url, encoding: null}, function (err, res, body) {
+  if (err) { throw err; }
+
+  if (!fs.existsSync(TMP)){
+    fs.mkdirSync(TMP);
+  }
+
+  fs.writeFileSync('tmp/aframe.zip', body);
+  fs.createReadStream('tmp/aframe.zip').pipe(unzip.Extract({ path: 'tmp/' }));
+  cpdir('tmp/aframe-' + BRANCH + '/docs', 'src/docs/' + TARGET, function (err) {
+    if (err) { throw err; }
+    console.log(BRANCH + ' docs successfully slurped to src/docs/' + TARGET);
+  });
+});


### PR DESCRIPTION
Playing around. This isn't quite as automated as we want since it only targets one version at a time, you still have to commit it, you have to re-deploy. 

```AFRAME_BRANCH=master AFRAME_TARGET=0.2.0 npm run docs```

- Will directories do for now? I can start to see why client-side is less work. Just always fetches every version from GitHub with no work on our side.
- Do we do docs for older minor versions (0.2.1 and 0.2.2) or do we just show the latest (0.2.2)?
- Should we represent the master branch docs?
- I named made self-referencing doc links end in ```.md``` instead of ```.html``` so people can browse using GitHub interface. We can do a replace server-side or have Hexo auto-redirect? The client-side solution would handle this better.