### PR TITLE
fix overflowing blog guide links

### DIFF
--- a/themes/aframe/source/css/secondary.styl
+++ b/themes/aframe/source/css/secondary.styl
@@ -216,6 +216,12 @@ a
     display block
     margin-top 20px
 
+.post .guide-links
+    .float-right
+        text-align right
+    span
+        max-width 40%
+
 // To prevent the active sections from loading.
 prevent_clicks_on_active_links = true
 


### PR DESCRIPTION
# before

<img width="732" alt="screen shot 2016-04-14 at 3 55 17 pm" src="https://cloud.githubusercontent.com/assets/674727/14546275/5017cc4c-0259-11e6-85a4-09d64402b425.png">

# after

<img width="787" alt="screen shot 2016-04-14 at 3 54 09 pm" src="https://cloud.githubusercontent.com/assets/674727/14546266/3a4621d4-0259-11e6-92d7-87fb3bfe2d3c.png">