### PR TITLE
remove `target="_blank"` from external links

### DIFF
--- a/themes/aframe/layout/blog.ejs
+++ b/themes/aframe/layout/blog.ejs
@@ -78,9 +78,9 @@
     <% } %>
 
     <footer class="footer footnote">
-      <p>Except where otherwise noted, content on this site is licensed under the <a href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank" rel="external">Creative Commons Attribution Share-Alike License v3.0</a> or any later version.</p>
+      <p>Except where otherwise noted, content on this site is licensed under the <a href="https://creativecommons.org/licenses/by-sa/3.0/" rel="external">Creative Commons Attribution Share-Alike License v3.0</a> or any later version.</p>
       <% if (!page.blog_index) { %>
-        <p>Caught a mistake? <br><br> <a href="<%- website_github_edit_url('_posts/' + page.slug + '.md') %>" class="github-file-link" target="_blank" rel="external">Suggest an edit to this post on GitHub</a></p>
+        <p>Caught a mistake? <br><br> <a href="<%- website_github_edit_url('_posts/' + page.slug + '.md') %>" class="github-file-link" rel="external">Suggest an edit to this post on GitHub</a></p>
       <% } %>
     </footer>
   </div>

--- a/themes/aframe/layout/index.ejs
+++ b/themes/aframe/layout/index.ejs
@@ -14,7 +14,7 @@
       <li class="menu-item"><a href="<%- url_for('faq/') %>">FAQ</a></li>
       <li class="menu-item"><a href="<%- url_for('blog/') %>">Blog</a></li>
       <li class="menu-item"><a href="<%- url_for('community/') %>">Community</a></li>
-      <li class="menu-item"><a href="<%- config.github.aframe.url %>" target="_blank" rel="external">GitHub</a></li>
+      <li class="menu-item"><a href="<%- config.github.aframe.url %>" rel="external">GitHub</a></li>
     </ul>
     <h1 class="slogan">
       Building blocks for the<br>
@@ -24,6 +24,6 @@
     <a href="<%- url_for('docs/guide/getting-started.html') %>" class="get-started nav-link<%- page.canonical_path.match(/docs/) ? ' current' : '' %>">
       Get Started
     </a>
-    <a class="credits borderless-link" href="http://mozvr.com/" target="_blank" rel="external"></a>
+    <a class="credits borderless-link" href="http://mozvr.com/" rel="external"></a>
   </div>
 </div>


### PR DESCRIPTION
still have to fix the Markdown-rendered links, such as [this one](https://aframe.io/docs/guide/):

> <p>Check out <a href="https://github.com/aframevr/awesome-aframe" target="_blank" rel="external">awesome things</a> that people have done with A-Frame.</p>
