### PR TITLE
bigger body fonts (fixes #78)

### DIFF
--- a/themes/aframe/source/css/_common.styl
+++ b/themes/aframe/source/css/_common.styl
@@ -180,6 +180,9 @@ p
     ol ol
         list-style circle
 
+    li + li
+        margin-top: .35rem
+
 .logo__wordmark
     background url(../images/aframe-name-pink.svg) no-repeat
     display block

--- a/themes/aframe/source/css/_settings.styl
+++ b/themes/aframe/source/css/_settings.styl
@@ -13,7 +13,6 @@ $body-font-size = 1.1rem
 $body-font-weight = 400
 $body-line-height = 1.6
 $code-font-size = .9rem
-$subnav-font-size = 1.0rem
 $table-heading-font-size = .9rem
 $table-body-font-size = .9rem
 

--- a/themes/aframe/source/css/_settings.styl
+++ b/themes/aframe/source/css/_settings.styl
@@ -9,11 +9,12 @@ $logo-font = $body-font
 $mono-font = $code-font
 
 // Font sizes
-$body-font-size = 1rem
-$body-font-weight = normal
+$body-font-size = 1.1rem
+$body-font-weight = 400
 $body-line-height = 1.5
-$code-font-size = 0.8rem
-
+$code-font-size = .9rem
+$table-heading-font-size = .9rem
+$table-body-font-size = .9rem
 
 // Colors
 $dark   = #2c3e50
@@ -32,7 +33,6 @@ $pink = rgb(239,45,94)
 
 $copy-link = #1497B8  // hsl(192, 80%, 40%)
 $copy-link-hover = #35c5e9  // hsl(192, 80%, 56%)
-
 
 // Miscellaneous
 $radius = 2px

--- a/themes/aframe/source/css/_settings.styl
+++ b/themes/aframe/source/css/_settings.styl
@@ -11,7 +11,7 @@ $mono-font = $code-font
 // Font sizes
 $body-font-size = 1.1rem
 $body-font-weight = 400
-$body-line-height = 1.5
+$body-line-height = 1.6
 $code-font-size = .9rem
 $subnav-font-size = 1.0rem
 $table-heading-font-size = .9rem

--- a/themes/aframe/source/css/_settings.styl
+++ b/themes/aframe/source/css/_settings.styl
@@ -13,6 +13,7 @@ $body-font-size = 1.1rem
 $body-font-weight = 400
 $body-line-height = 1.5
 $code-font-size = .9rem
+$subnav-font-size = 1.0rem
 $table-heading-font-size = .9rem
 $table-body-font-size = .9rem
 

--- a/themes/aframe/source/css/secondary.styl
+++ b/themes/aframe/source/css/secondary.styl
@@ -65,6 +65,7 @@ a
 .subnav-link
     display block
     color rgba(0,0,0,0.35)
+    font-size $subnav-font-size
     text-indent -10px
     padding-left 10px
     transition 0.05s color ease
@@ -325,12 +326,11 @@ if numbered_debug
         color #fff
         display inline-block
         font-family $code-font
-        font-weight 600
         margin 5px 0
         padding 12px 24px
         transition 0.15s ease
         &.btn-download
-            padding 12px 14px
+            padding 12px 8px
             min-width 220px
         &:hover
             background-color lighten($blue, 15%)

--- a/themes/aframe/source/css/secondary.styl
+++ b/themes/aframe/source/css/secondary.styl
@@ -131,9 +131,9 @@ a
     th
         background #2ac
         color #fff
-        font-size 0.8em
-        font-weight 500
-        line-height 1.6
+        font-size $table-heading-font-size
+        font-weight 400
+        line-height 1.8
         text-align left
         white-space nowrap
         + th
@@ -141,9 +141,11 @@ a
 
     td
         background #fff
-        border-bottom 1px solid #eee
-        font-size 12px
+        font-size $table-body-font-size
         vertical-align top
+
+    tr:not(:last-child) td
+        border-bottom 1px solid #eee
 
 // The sub-heading above the docs title
 .content--structured .page__section
@@ -250,7 +252,7 @@ if numbered_debug
 .highlight
     position relative
     background-color $codebg
-    padding .8em .8em .4em
+    padding .2em .2em .1em
     line-height 1.1em
     border-radius $radius
     overflow-x auto

--- a/themes/aframe/source/css/secondary.styl
+++ b/themes/aframe/source/css/secondary.styl
@@ -65,7 +65,6 @@ a
 .subnav-link
     display block
     color rgba(0,0,0,0.35)
-    font-size $subnav-font-size
     text-indent -10px
     padding-left 10px
     transition 0.05s color ease
@@ -90,7 +89,7 @@ a
 
 .sidebar
     padding 40px
-    width 260px
+    width 280px
 
 .content
     flex 1


### PR DESCRIPTION
# After

<img width="637" alt="screen shot 2016-05-31 at 11 29 33 am" src="https://cloud.githubusercontent.com/assets/674727/15686256/4c0707fe-2724-11e6-8ee2-dee039c5c111.png">

# Before

<img width="654" alt="screen shot 2016-05-27 at 11 24 54 am" src="https://cloud.githubusercontent.com/assets/674727/15617404/aec761b0-23fd-11e6-9d61-2933d4fb6648.png">
