### PR TITLE
Add transparency example to FAQ page

### DIFF
--- a/src/faq/index.md
+++ b/src/faq/index.md
@@ -172,6 +172,8 @@ We express it in code and domains as "aframe" as much as possible. Sometimes we 
 
 Transparency is tricky in 3D graphics. If you are having issues where transparent images in the foreground do not composite correctly over images in the background, it is probably due to underlying design of the OpenGL compositor (which WebGL is an API for). In an ideal scenario, transparency in A-Frame would "just work", regardless of where the developer places an image in 3D space, or in which order they define the elements in markup. In the current version of A-Frame, however, it is easy to create scenarios where foreground images occlude background images. This creates confusion and unwanted visual defects. A possible workaround is to try reordering your elements defined in HTML and see if that produces more expected results.
 
+Take a look at this [example](http://codepen.io/bryik/pen/pyMoGb). Here we have two sets of identical transparent circles. One set is positioned front-to-back while the other is back-to-front. Notice that the circles are only transparent when positioned back-to-front (relative to the camera).
+
 [aframe-react]: https://github.com/ngokevin/aframe-react
 [archive3d]: http://archive3d.net/
 [awesome]: https://github.com/aframevr/awesome-aframe


### PR DESCRIPTION
I was puzzled why only some of the circles on a scene I was making were transparent, eventually got it working by positioning them back-to-front. Thought this info might be useful to others.