### PR TITLE
fix <h3> headings in Docs

### DIFF
--- a/themes/aframe/source/css/_common.styl
+++ b/themes/aframe/source/css/_common.styl
@@ -42,30 +42,31 @@ a.borderless-link
     position absolute
     width 1px
 
-h1, h2, h3, h4
-    font-weight 600
-    color $dark
-
 strong
     font-weight 600
 
 code, pre
-    background-color $codebg
-    font $code-font-size $code-font-default
+    font-size $code-font-size
+    font-family $code-font-default
 
 .font-loaded-mono code,
 .font-loaded-mono pre
     font-family $code-font
 
 code
-    color #e96900
-    padding 3px 5px
-    margin 0 2px
-    border-radius 2px
-    white-space nowrap
+
+
+p, li, dd
+    code
+        font-weight 600
+        padding 0 0.25ch
 
 p
     word-spacing 0.05em
+
+h1, h2, h3, h4
+    font-weight 600
+    color $dark
 
 .btn
     cursor pointer
@@ -107,6 +108,10 @@ p
         margin 2em 0 .8em
         padding-bottom .7em
         border-bottom 1px solid $border
+    h3
+        color $fair
+    h3, h3 code
+        font-size 1.3rem
     h3, h4
         margin 2em 0 1.2em
         position relative

--- a/themes/aframe/source/css/_settings.styl
+++ b/themes/aframe/source/css/_settings.styl
@@ -17,6 +17,7 @@ $code-font-size = 0.8rem
 
 // Colors
 $dark   = #2c3e50
+$fair = lighten(#2c3e50, 20%)
 $medium = #333
 $light  = #7f8c8d
 $green  = #4b8


### PR DESCRIPTION
especially noticeable on [http://localhost:4000/docs/core/entity.html](http://localhost:4000/docs/core/entity.html)

## before
<img width="1020" alt="screen shot 2016-05-31 at 12 14 42 pm" src="https://cloud.githubusercontent.com/assets/203725/15687378/3621ad2c-2729-11e6-8d94-ca317464d0d5.png">

## after
<img width="995" alt="screen shot 2016-05-31 at 12 20 38 pm" src="https://cloud.githubusercontent.com/assets/203725/15687471/d3f2d97c-2729-11e6-984f-3b1be5dd203b.png">
