### PR TITLE
automated table of contents

### DIFF
--- a/src/faq/index.md
+++ b/src/faq/index.md
@@ -2,6 +2,7 @@
 title: FAQ
 type: faq
 layout: page
+toc: true
 ---
 
 ## What is A-Frame?

--- a/themes/aframe/layout/docs.ejs
+++ b/themes/aframe/layout/docs.ejs
@@ -59,7 +59,15 @@
     <% } %>
     <h1 class="page__title"><%= page.title %></h1>
 
-    <%- page.content %>
+    <% var contents = page.content.replace(/\<!--\s*toc\s*-->/gi,
+                                           '<!--toc-->').split('<!--toc-->'); %>
+    <% if (contents.length > 1) { %>
+      <%- contents[0] %>
+      <%- partial('partials/toc', {page: page}) %>
+      <%- contents[1] %>
+    <% } else { %>
+      <%- page.content %>
+    <% } %>
 
     <!-- Previous / Next navigation. -->
     <footer class="footer guide-links c">

--- a/themes/aframe/layout/page.ejs
+++ b/themes/aframe/layout/page.ejs
@@ -9,6 +9,10 @@
   <div class="copy__wrap">
     <h1 class="page__title"><%- page.title %></h1>
 
+    <% if (page.toc) { %>
+      <%- partial('partials/toc', {page: page}) %>
+    <% } %>
+
     <%- page.content %>
 
     <%- partial('partials/docs/footer', {item: page}) %>

--- a/themes/aframe/layout/partials/toc.ejs
+++ b/themes/aframe/layout/partials/toc.ejs
@@ -1,0 +1,22 @@
+<% var toc = table_of_contents(page.content); %>
+
+<% if (toc.length) { %>
+  <h2>Table of Contents</h2>
+
+  <ul id="toc">
+    <% toc.forEach(function (item) { %>
+      <li>
+        <a href="<%- item.href %>"><%= item.title %></a>
+
+        <!-- Nested. -->
+        <% if (item.children) { %>
+          <ul>
+            <% item.children.forEach(function (innerItem) { %>
+              <li><a href="<%- innerItem.href %>"><%= innerItem.title %></a></li>
+            <% }); %>
+          </ul>
+        <% } %>
+      </li>
+    <% }); %>
+  </ul>
+<% } %>

--- a/themes/aframe/source/css/_common.styl
+++ b/themes/aframe/source/css/_common.styl
@@ -188,7 +188,9 @@ h1, h2, h3, h4
     ol ol
         list-style circle
 
-    li + li
+    li + li,
+    ul ul li,
+    ol ol li
         margin-top: .35rem
 
 .logo__wordmark

--- a/themes/aframe/source/css/secondary.styl
+++ b/themes/aframe/source/css/secondary.styl
@@ -498,5 +498,8 @@ if numbered_debug
         margin-left -25px
         padding-left 35px
 
+#toc a
+    border-bottom 0
+
 video
     max-width 100%


### PR DESCRIPTION
Remove the error-proneness of updating all the anchor links. Easier to parse FAQ.

For docs, add HTML comment for toc `<!-- toc -->`.

For pages, use YAML `toc: true`

<img width="747" alt="screen shot 2016-06-09 at 4 46 13 pm" src="https://cloud.githubusercontent.com/assets/674727/15936118/b358082e-2e61-11e6-97c9-8165e944964e.png">


<img width="780" alt="screen shot 2016-06-03 at 6 16 01 pm" src="https://cloud.githubusercontent.com/assets/674727/15796676/3ff2ab5e-29b7-11e6-8489-50440e0d2da0.png">

@cvan 