### PR TITLE
fix wonky Getting Started > Builds buttons

### DIFF
--- a/themes/aframe/layout/layout.ejs
+++ b/themes/aframe/layout/layout.ejs
@@ -9,7 +9,7 @@
 <% var pageTitle = page.title ? page.title + delimiter + sectionTitle : '' %>
 
 <!DOCTYPE html>
-<html lang="en" data-is-home="<%- isHome %>" data-is-mobile="false" data-supports-vr="false" data-supports-touch="false" data-root-url="<%- config.root %>" data-title="{title} | A-Frame" data-is-spa="<% config.spa %>" data-ga-id="<%- config.google_analytics %>">
+<html lang="en" data-is-home="<%- isHome %>" data-is-mobile="false" data-supports-vr="false" data-supports-touch="false" data-root-url="<%- config.root %>" data-title="{title} | A-Frame" data-is-spa="<%= config.spa %>" data-ga-id="<%- config.google_analytics %>" data-aframe-version="<%= config.aframe_version %>" data-docs-version="<%= docs_active_version(page) %>">
   <head>
     <title><%- page.full_title || (isHome ? projectTitle : pageTitle + config.title) %></title>
     <%- partial('partials/force_https') %>

--- a/themes/aframe/source/css/secondary.styl
+++ b/themes/aframe/source/css/secondary.styl
@@ -354,6 +354,9 @@ if numbered_debug
     font-size 0.8rem
     font-weight normal
     margin-left 10px
+    &:after
+        display block
+        content ""
 
 .content--structured
     h2[id],

--- a/themes/aframe/source/js/docs.js
+++ b/themes/aframe/source/js/docs.js
@@ -43,6 +43,15 @@ if (content) {
       }
     }
   });
+
+  // NOTE: Hack because variables doesn't get interpolated correctly in Markdown code blocks.
+  // This is for `/docs/<version>/guide/getting-started.html`
+  if (document.querySelector('#builds')) {
+    var versionEls = document.querySelectorAll('.highlight .code .string');
+    for (var i = 0; i < versionEls.length; ++i) {
+      versionEls[i].textContent = versionEls[i].textContent.replace('\{\{ version \}\}', settings.docsVersion);
+    }
+  }
 }
 
 })();


### PR DESCRIPTION
for
- http://localhost:4000/docs/0.1.0/guide/installation.html
- http://localhost:4000/docs/0.2.0/guide/getting-started.html
- http://localhost:4000/docs/master/guide/getting-started.html

<hr>

* moved the `<script>` hack out of the `master` docs: aframevr/aframe#1594
* added the `<script>` hack to the `docs.js` here
* removed the newline from `master` docs so line breaks are consistent: aframevr/aframe#1594
* added CSS for consistent line breaks between all doc versions here
