### PR TITLE
Fix #297 - Add 'replay' button to examples

### DIFF
--- a/themes/aframe/layout/partials/examples/iframe.ejs
+++ b/themes/aframe/layout/partials/examples/iframe.ejs
@@ -3,4 +3,8 @@
         height="100%"
         allowfullscreen="yes" scrolling="no"
         src="<%- page.scene_url %>"></iframe>
-<a href="<%- page.source_url %>" class="btn example__viewsource" id="exampleViewsource" target="_blank">View Source</a>
+
+<div class="example__controls">
+  <a href="" id="exampleReplay" class="btn" rel="nofollow">Replay</a>
+  <a href="<%- page.source_url %>" class="btn" id="exampleViewsource" target="_blank">View Source</a>
+</div>

--- a/themes/aframe/source/css/index.styl
+++ b/themes/aframe/source/css/index.styl
@@ -97,30 +97,28 @@ ul {
   display: flex;
   flex-direction: column;
 }
-.example__viewsource {
-  background: rgba(0,0,0,0.35);
-  color: #fff;
-  display: block;
-  font-size: 12px;
-  line-height: 1.5;
-  padding: 5px 10px;
+.example__controls {
   position: absolute;
   text-transform: uppercase;
   top: 5px;
   right: 5px;
   z-index: 2;
+  font-size: 12px;
+  line-height: 1.5;
+  a {
+    background: rgba(0,0,0,0.35);
+    color: #fff;
+    display: inline-block;
+    padding: 5px 10px;
+    &:active, &:hover {
+      background-color: #ef2d5e;
+    }
+  }
 }
-.example__viewsource[href="#"] {
+.aframe-animation .example__controls {
   display: none;
 }
-.example__viewsource:active,
-.example__viewsource:hover {
-  background-color: #ef2d5e;
-}
-.aframe-animation .example__viewsource {
-  display: none;
-}
-[data-is-mobile="true"] .example__viewsource {
+[data-is-mobile="true"] .example__controls {
   display: none;
 }
 .page__title {
@@ -275,13 +273,13 @@ ul {
   }
 }
 @media screen and (min-width: 480px) {
-  .example__viewsource {
+  .example__controls {
     top: 20px;
     right: 20px;
   }
 }
 @media screen and (min-width: 800px) {
-  .example__viewsource {
+  .example__controls {
     top: 30px;
     right: 30px;
   }

--- a/themes/aframe/source/js/examples.js
+++ b/themes/aframe/source/js/examples.js
@@ -156,11 +156,19 @@ function init () {
     this.setAttribute('href', getNextNavLink());
   });
 
+  var exampleIframe = document.querySelector('#exampleIframe');
+  var replayLink = document.querySelector('#exampleReplay');
+  if (replayLink) {
+    replayLink.addEventListener('click', function (e) {
+      e.preventDefault();
+      exampleIframe.src = exampleIframe.src;
+    });
+  }
+
   if (settings.isSpa) {
     var showPage = singlePage(function (href) {
       var hrefWithSlash = forceTrailingSlash(parseUrl(href).pathname);
 
-      var exampleIframe = document.querySelector('#exampleIframe');
       if (exampleIframe) {
         if (!settings.isHome) {
           document.title = getTitle(currentExample.title);


### PR DESCRIPTION
Left `href` empty so if we choose to use querystring to trigger stuff in the future there should be no problem.  Also avoided `window.location`/JavaScript redirect.