### PR TITLE
Fix broken TOC links in Getting Started doc

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -37,7 +37,7 @@ hexo.extend.helper.register('table_of_contents', function (content) {
     var link = $h2.find('a')[0];
     var item = {
       title: link.attribs.title,
-      href: link.attribs.href,
+      href: link.attribs.href.toLowercase(),
       children: []
     };
 
@@ -46,7 +46,7 @@ hexo.extend.helper.register('table_of_contents', function (content) {
     for (var i = 0; i < links.length; i++) {
       item.children.push({
         title: links[i].attribs.title,
-        href: links[i].attribs.href
+        href: links[i].attribs.href.toLowercase()
       });
     }
     return item;


### PR DESCRIPTION
The docs are parsed and given lowercase anchor IDs but our helper doesn't do a lowercase conversion, thus TOC links can break.