### PR TITLE
Add allowvr attribute to iframe to allow devices to access examples

### DIFF
--- a/themes/aframe/layout/partials/examples/iframe.ejs
+++ b/themes/aframe/layout/partials/examples/iframe.ejs
@@ -2,8 +2,8 @@
         width="100%"
         height="100%"
         allowfullscreen="yes" scrolling="no"
+        allowvr
         src="<%- page.scene_url %>"></iframe>
-
 <div class="example__controls">
   <a href="" id="exampleReplay" class="btn" rel="nofollow">Replay</a>
   <a href="<%- page.source_url %>" class="btn" id="exampleViewsource" target="_blank">View Source</a>


### PR DESCRIPTION
Adding the `allowvr` attribute to the iframe so that the examples work with connected devices. 

Tested with the Oculus Rift in Chromium build.