### PR TITLE
Fix the syntax coloring for attributes

### DIFF
--- a/themes/aframe/source/css/_syntax.styl
+++ b/themes/aframe/source/css/_syntax.styl
@@ -7,7 +7,7 @@ pre
   .constant
     color: #0092db
   .keyword,
-  .attribute
+  .attr
     color: #e96900
   .number,
   .literal


### PR DESCRIPTION
![screenshot_2016-10-24_20-47-39](https://cloud.githubusercontent.com/assets/757912/19672446/65c83af8-9a2b-11e6-988f-6dceb1b904cc.png)
- Closes #335 