### PR TITLE
Add search to the sidebar

### DIFF
--- a/themes/aframe/layout/docs.ejs
+++ b/themes/aframe/layout/docs.ejs
@@ -57,10 +57,7 @@
           <%- activeVersion %> &rsaquo; <%= activeSection.section_title %>
         </a>
       </p>
-      <div class="docs-search-wrapper">
-        <input id="search" type="search" placeholder="&#128269; Search <%- activeVersion %> docs&hellip;"></input>
-        <p class="stackoverflow-link">Got a question? <a href="http://stackoverflow.com/questions/tagged/aframe">Ask on StackOverflow.</a></p>
-      </div>
+      <%- partial('partials/search_field', {location: 'docs'}) %>
     </div>
     <h1 class="page__title"><%= page.title %></h1>
 

--- a/themes/aframe/layout/partials/search.ejs
+++ b/themes/aframe/layout/partials/search.ejs
@@ -1,14 +1,16 @@
 <!-- Algolia search. -->
 <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>
 <script type="text/javascript">
-  docsearch({
+  var searchConfig = {
     apiKey: '9e4a51a1da70daf959bd4750a3fa8f52',
     indexName: 'aframe',
-    inputSelector: '#search',
     algoliaOptions: {
       facetFilters: ['version:<%- docs_active_version(page) || config.aframe_version %>'],
       hitsPerPage: 10
     },
     debug: false
-  });
+  };
+
+  docsearch(Object.assign(searchConfig, {inputSelector: '.docs-search-sidebar .search-field'}));
+  docsearch(Object.assign(searchConfig, {inputSelector: '.docs-search-docs .search-field'}));
 </script>

--- a/themes/aframe/layout/partials/search_field.ejs
+++ b/themes/aframe/layout/partials/search_field.ejs
@@ -1,0 +1,7 @@
+<% var activeSection = '' %>
+<% var activeVersion = docs_active_version(page) %>
+<% var fieldLocation = locals.location %>
+<div class="docs-search-wrapper docs-search-<%= fieldLocation %>">
+  <input type="search" class="search-field" placeholder="&#128269; Search <%- activeVersion %> docs&hellip;"></input>
+  <p class="stackoverflow-link">Question? <a href="http://stackoverflow.com/questions/tagged/aframe">Ask on StackOverflow.</a></p>
+</div>

--- a/themes/aframe/layout/partials/secondary/sidebar_header.ejs
+++ b/themes/aframe/layout/partials/secondary/sidebar_header.ejs
@@ -61,6 +61,8 @@ links = links.map(function (link) {
     </a>
   </header>
 
+  <%- partial('partials/search_field', {location: 'sidebar'}) %>
+
   <ul id="nav" class="nav">
     <% links.forEach(function (link) { %>
       <li <% if (link.slug) { %> data-slug="<%= link.slug %>"<% } %> class="nav-item">

--- a/themes/aframe/source/css/search.styl
+++ b/themes/aframe/source/css/search.styl
@@ -5,7 +5,7 @@
     font-size 12px
     width 100%
 
-#search
+.search-field
     -moz-appearance none
     -webkit-appearance none
     border 1px solid #DADADA
@@ -14,13 +14,22 @@
     display flex
     font-size 15px
     height 30px
+    outline-color $color-primary
     padding 0 5px 0 10px
     width 100%
     +media--desktop()
         width 240px
+    
+.docs-search-wrapper
+    +media--desktop()
+        margin-right 16px
 
-[data-is-ios="true"] #search
+[data-is-ios="true"] .search-field
     padding-bottom 7px
+
+.docs-search-sidebar
+    +media--desktop()
+        display none
 
 /* Main category headers */
 .algolia-docsearch-suggestion--category-header {
@@ -45,3 +54,24 @@
 .aa-cursor .algolia-docsearch-suggestion {
   background: #EBEBFB;
 }
+
+@media (max-width: 768px)
+    .algolia-autocomplete .algolia-docsearch-suggestion--content,
+    .algolia-autocomplete .algolia-docsearch-suggestion--subcategory-column
+        float none
+        width 100%
+
+    .algolia-autocomplete .algolia-docsearch-suggestion--subcategory-column
+        text-align: left
+
+    .algolia-autocomplete .algolia-docsearch-suggestion--subcategory-column:before
+        right auto
+        left -1px
+    
+    .algolia-autocomplete .ds-dropdown-menu
+        margin-left -32px
+        margin-right -32px
+        min-width 100%
+    
+    .docs-search-docs
+        display none

--- a/themes/aframe/source/css/secondary.styl
+++ b/themes/aframe/source/css/secondary.styl
@@ -430,21 +430,27 @@ video
         display block
 
 .docs-search-wrapper
-    align-items flex-end
+    align-items flex-start
     display flex
     flex-direction column
     margin-bottom 25px
     max-width 100%
-    +media--desktop()
-        position absolute
-        right 0
-        top 0
+
     .stackoverflow-link
+        display none
         font-family $body-font
         font-size 12px
         font-weight 400
         margin-top 5px
         text-transform uppercase
+        +media--desktop()
+            display block
+
+.docs-search-docs
+    align-items flex-end
+    position absolute
+    right 0
+    top 0
 
 .docs-header + blockquote
     margin 4em 0 2em


### PR DESCRIPTION
- Add search to the sidebar at small screen sizes.
- Modify the drop-down styles so they fit better in a single column. 
- Closes #393

![screenshot_2016-10-27_21-56-16](https://cloud.githubusercontent.com/assets/757912/19795588/c0362e74-9c91-11e6-9b9c-49abde2b1089.png)
