### PR TITLE
enable working 360° Video on mobile

### DIFF
--- a/src/_data/examples.yml
+++ b/src/_data/examples.yml
@@ -39,7 +39,7 @@ showcase:
   source_url: https://github.com/aframevr/aframe/blob/v0.5.0/examples/boilerplate/360-video/index.html
   title: 360&deg; Video
   supports:
-    mobile: false
+    mobile: true
 
 - section: showcase
   slug: animation


### PR DESCRIPTION
per this PR: aframevr/aframe#2656

<hr>

btw, what's the recommended way you cherry-pick changes to the A-Frame Examples pages (manually)? I [see that](https://github.com/aframevr/aframevr.github.io/commits/master) A-Frobot handles Docs cherry-picks.
