### PR TITLE
do not use `package-lock.json` (workaround for `node-pre-gyp` bug on npm5: mapbox/node-pre-gyp#298) (fixes #439)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
workaround for `node-pre-gyp` bug on npm5: mapbox/node-pre-gyp#298