### PR TITLE
Unhide 'Get Started' link on >mobile displays.

### DIFF
--- a/themes/aframe/source/css/examples.styl
+++ b/themes/aframe/source/css/examples.styl
@@ -4,7 +4,7 @@
   .mobile-get-started {
     display: inline-block;
     position: absolute;
-    padding: 4px 5vw;
+    padding: 1.5vw 5vw;
     margin: 0;
     right: 20px;
     top: 20px;

--- a/themes/aframe/source/css/examples.styl
+++ b/themes/aframe/source/css/examples.styl
@@ -5,7 +5,7 @@
     display: inline-block;
     position: absolute;
     padding: 4px 5vw;
-    margin-top: 0;
+    margin: 0;
     right: 20px;
     top: 20px;
   }

--- a/themes/aframe/source/css/index.styl
+++ b/themes/aframe/source/css/index.styl
@@ -270,7 +270,7 @@ a.mozilla-logo:hover {
   opacity: 0.8;
 }
 .mobile-get-started {
-  display: none;
+  margin: 20px 0;
 }
 @media screen and (max-width: 399px) {
   #logo {

--- a/themes/aframe/source/css/index.styl
+++ b/themes/aframe/source/css/index.styl
@@ -270,7 +270,7 @@ a.mozilla-logo:hover {
   opacity: 0.8;
 }
 .mobile-get-started {
-  margin: 20px 0;
+  margin: 0 0 20px;
 }
 @media screen and (max-width: 399px) {
   #logo {


### PR DESCRIPTION
We shouldn't hide the *Get Started* link on larger screens on the `/examples` page, because some devices (e.g. iPad) are redirected here from the homepage, and have no other way to get to the documentation.

Fixes #435.

![screen shot 2017-07-15 at 5 23 54 pm](https://user-images.githubusercontent.com/1848368/28243537-d48e609e-6982-11e7-9189-5f91f5a3cce9.png)

![screen shot 2017-07-15 at 5 24 04 pm](https://user-images.githubusercontent.com/1848368/28243539-e5fd092a-6982-11e7-8f23-60eb2cfc03c4.png)

