### PR TITLE
do not show two "Get Started" buttons on homepage (fixes #446)

### DIFF
--- a/themes/aframe/source/css/index.styl
+++ b/themes/aframe/source/css/index.styl
@@ -17,6 +17,10 @@ em {
 
 html[data-is-home="true"] {
   min-width: 1000px;
+
+  .sidebar .get-started {
+    display: none;
+  }
 }
 body {
   color: #fff;


### PR DESCRIPTION
# [before](https://aframe.io/)

## [homepage](https://aframe.io/)

https://aframe.io/
[<img src="https://user-images.githubusercontent.com/203725/28557624-6167706e-70c2-11e7-96d8-855ad069e3cb.png">](https://screenshots.firefox.com/1C80cumdWjONxLQW/aframe.io)

https://aframe.io/examples/showcase/helloworld/
[<img src="https://user-images.githubusercontent.com/203725/28557632-6bda1984-70c2-11e7-913e-ea21fd1e7563.png">](https://screenshots.firefox.com/UfdCaCOEalXW8bMt/aframe.io)

<hr>

# [after](http://localhost:4000/)

[`http://localhost:4000/`](http://localhost:4000/)
[<img src="https://user-images.githubusercontent.com/203725/28557635-745e1d8a-70c2-11e7-8633-ed8bdc9a459c.png">](https://screenshots.firefox.com/WCzL8eIP0wG1Vb7H/localhost)

[`http://localhost:4000/examples/showcase/helloworld/`](http://localhost:4000/examples/showcase/helloworld/)
[<img src="https://user-images.githubusercontent.com/203725/28557716-e7f6e9b6-70c2-11e7-81d5-f6dc2f0ed8e3.png">](https://screenshots.firefox.com/MqMqr5DReib7XmyN/localhost)
