### PR TITLE
blog.ejs: Remove navigation arrows

### DIFF
--- a/themes/aframe/layout/blog.ejs
+++ b/themes/aframe/layout/blog.ejs
@@ -101,18 +101,18 @@
           <% } %>
         </article>
 
-        <footer class="footer guide-links c">
-          <% // Yes, these are correct. %>
-          <% var prevPost = page.next %>
-          <% var nextPost = page.prev %>
-          <% if (prevPost) { %>
-            <span class="float-left"><a href="<%- page_url(prevPost.path) %>" class="guide-link guide-link-left">← <%- prevPost.title %></a></span>
-          <% } %>
-          <% if (nextPost) { %>
-            <span class="float-right"><a href="<%- page_url(nextPost.path) %>" class="guide-link guide-link-right"><%- nextPost.title %> →</a></span>
-          <% } %>
-        </footer>
-      <% } %>
+     
+
+
+
+
+
+
+
+
+
+
+
 
       <footer class="footer footnote">
         <p>Except where otherwise noted, content on this site is licensed under the <a href="https://creativecommons.org/licenses/by-sa/3.0/" rel="external">Creative Commons Attribution Share-Alike License v3.0</a> or any later version.</p>


### PR DESCRIPTION
Remove navigation arrows at the bottom-left of the homepage.

Fixes https://github.com/aframevr/aframe-site/issues/445