### PR TITLE
Updated Audio Visualization url in examples.yml

### DIFF
--- a/src/_data/examples.yml
+++ b/src/_data/examples.yml
@@ -54,8 +54,8 @@ showcase:
 
 - section: showcase
   slug: audio-visualization
-  scene_url: https://ngokevin.github.io/kframe/components/audioanalyser/examples/showcase/
-  source_url: https://github.com/ngokevin/kframe/blob/b78fb6a17d39556fcf61d00f5afb8b835651e473/components/audioanalyser/examples/showcase/index.html
+  scene_url: https://supermedium.github.io/superframe/components/audioanalyser/examples/showcase/
+  source_url: https://github.com/supermedium/superframe/blob/c011b597de0d2e0b7fc26e0d16f0cb1dfc8a42e9/components/audioanalyser/examples/showcase/index.html
   title: Audio Visualization
   supports:
     mobile: false


### PR DESCRIPTION
## Problem:

When I click on the "Audio Visualization" link from aframe.io, a github 404 is returned.
Direct URL: https://aframe.io/examples/showcase/audio-visualization/

## Screenshot

<img width="1195" alt="screen shot 2018-12-14 at 12 38 24" src="https://user-images.githubusercontent.com/288263/50020975-304b7500-ff9d-11e8-85c3-8419357d91af.png">

## Solution:

The repo https://www.github.com/ngokevin/kframe redirects to https://github.com/supermedium/superframe/ .

So the fix is to update the old URL with the updated URL.

- Old URL: https://ngokevin.github.io/kframe/components/audioanalyser/examples/showcase/
- New URL: https://supermedium.github.io/superframe/components/audioanalyser/examples/showcase/
