### PR TITLE
Fix path to checkLinks.js script for npm run test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "installdocs": "multidep multidep.json && npm run copydocs",
     "server": "hexo server",
     "start": "npm run dev",
-    "test": "node script/checkLinks.js"
+    "test": "node tests/checkLinks.js"
   }
 }


### PR DESCRIPTION
It doesn't check anything currently because all the index.html are empty when I'm executing in node 22, see https://github.com/aframevr/aframe-site/issues/533#issuecomment-2160123515 but at least the path is fixed.