### PR TITLE
Fix moonrider github url

### DIFF
--- a/src/_data/examples.yml
+++ b/src/_data/examples.yml
@@ -66,7 +66,7 @@ showcase:
 - section: showcase
   slug: moonrider
   scene_url: https://moonrider.xyz
-  source_url: https://github.com:supermedium/moonrider
+  source_url: https://github.com/supermedium/moonrider
   title: Moon Rider
   supports:
     mobile: false


### PR DESCRIPTION
Fix moonrider github url that was reported by `npm run test` (checkLinks.js script), although we don't seem to use it in the generated html.