### PR TITLE
Fix internal .md links to .html

### DIFF
--- a/_config.local.yml.dist
+++ b/_config.local.yml.dist
@@ -12,8 +12,8 @@ root: /
 force_https: false
 
 aframe_lib:
-  home_url: http://localhost:9000
-  examples_url: http://localhost:9000/examples
+  home_url: http://localhost:4000
+  examples_url: http://localhost:8080
   prod_home_url: https://aframe.io
   prod_examples_url: https://aframe.io/aframe/examples
 

--- a/scripts/filters.js
+++ b/scripts/filters.js
@@ -25,40 +25,22 @@ function convertProdToDevUrls (str) {
   }
   // Careful. Order does matter here.
   if (this.config.aframe_lib.prod_examples_url) {
-    str = str.replace(new RegExp(this.config.aframe_lib.prod_examples_url, 'gi'),
-                      this.config.aframe_lib.examples_url);
+    str = str.replaceAll(this.config.aframe_lib.prod_examples_url, this.config.aframe_lib.examples_url);
   }
   if (this.config.aframe_lib.prod_home_url) {
-    str = str.replace(new RegExp(this.config.aframe_lib.prod_home_url, 'gi'),
-                      this.config.aframe_lib.home_url);
+    str = str.replaceAll(this.config.aframe_lib.prod_home_url, this.config.aframe_lib.home_url);
   }
   return str;
 }
 
-hexo.extend.filter.register('after_render:json', function (obj, data) {
-  var self = this;
-  return JSON.parse(JSON.stringify(obj), function (key, val) {
-    return convertProdToDevUrls.bind(self)(val);
-  });
-});
+hexo.extend.filter.register('after_post_render', function (data) {
+  data.content = convertProdToDevUrls.bind(this)(data.content);
 
-hexo.extend.filter.register('before_post_render', function (data) {
-  // On the server, <!--toc--> was getting stripped during the render. Replace it
-  // with a dummy <div>, which we'll later restore to <!--toc-->.
-  data.content = data.content.replace('<!--toc-->', '<div id="toc"></div>');
-  return data;
-});
-
-hexo.extend.filter.register('after_render:html', function (str, data) {
-  str = convertProdToDevUrls.bind(this)(str);
-
-  if (data.path && data.path.substr(-3) === '.md') {
-    str = str.replace(/href="([^"]+)"/g, function (origStr, p1) {
+  if (data.source && data.source.endsWith('.md')) {
+    data.content = data.content.replace(/href="([^"]+)"/g, function (origStr, p1) {
       return 'href="' + fixMarkdownLink(p1) + '"';
     });
   }
 
-  // Restore Table of Contents marker.
-  str = str.replace('<div id="toc"></div>', '<!--toc-->');
-  return str;
+  return data;
 });

--- a/src/_posts/gamestate.md
+++ b/src/_posts/gamestate.md
@@ -18,8 +18,6 @@ built several non-trivial WebVR applications, we'll go over how we started to
 bring these ideas of state management into A-Frame's DOM-based entity-component
 architecture.
 
-<!--toc-->
-
 <!--more-->
 
 ## Initial Approach with Redux

--- a/src/_posts/motion-capture.md
+++ b/src/_posts/motion-capture.md
@@ -35,8 +35,6 @@ actions, on any device from anywhere without a headset.
 
 <!-- more -->
 
-<!--toc-->
-
 ## Motion Capture Makes VR Developer Lives Easier
 
 ![Rapid Development](https://cloud.githubusercontent.com/assets/674727/24733615/9cb99dae-1a2d-11e7-85e3-a75d6c06bb91.gif)


### PR DESCRIPTION
- modify internal .md links to .html, after_render:html filter doesn't exist anymore, using now after_post_render
- properly modify urls for local dev (I didn't find any json file to transform, so removed that code)
  If you want to test:
```
cp _config.local.yml.dist _config.local.yml
npm run dev
http://localhost:4000/blog/screenshot/
Anime UI example link is local
```
- remove unused toc transform, first this wasn't an issue anymore, it was used on two pages and did nothing, we have table-of-contents div that's working on all pages

This closes #541 @dmarcos 