### PR TITLE
New supermedium Discord invite link

### DIFF
--- a/src/_posts/webxr-ar-module.md
+++ b/src/_posts/webxr-ar-module.md
@@ -54,7 +54,7 @@ Developers will be able to cast rays into the real world and retrieve a list of 
 
 When entering AR or VR mode, only WebGL content and the real world or camera image are rendered on screen. DOM layers will allow overlaying HTML elements to present for instance 2D UIs, instructions or contextual information associated to virtual or real world objects.
 
-**[Join our discord channel](https://discordapp.com/invite/tGYjkYr)**. The community will love to see what you make.
+**[Join our discord channel](/community/#discord)**. The community will love to see what you make.
 
 If you'd like to continue to support us, please **[subscribe to the A-Frame
 newsletter](https://aframe.io/subscribe/)** where we'll not only provide

--- a/src/community/index.md
+++ b/src/community/index.md
@@ -67,7 +67,7 @@ Meet the team!
 </ul>
 
 To get A-Frame questions answered, we're also hanging out on the [Supermedium
-Discord](https://discord.gg/tGYjkYr). Feel from to come and ask us questions
+Discord](#discord). Feel from to come and ask us questions
 directly!
 
 ## News
@@ -87,7 +87,7 @@ directly!
 
 ## Discord
 
-There's an #aframe channel on the [Supermedium Discord](https://discord.com/invite/tGYjkYr).
+There's an #aframe channel on the [Supermedium Discord](https://discord.gg/NPgArtG3Qz).
 
 The more general [WebXR Discord](https://discord.gg/jJxvuW97c4) also has an #a-frame channel.
 

--- a/themes/aframe/layout/partials/secondary/sidebar_header.ejs
+++ b/themes/aframe/layout/partials/secondary/sidebar_header.ejs
@@ -5,7 +5,7 @@ var links = [
   {url: 'community/', text: 'Community'},
   {url: 'showcase/', text: 'Showcase'},
   {url: config.github.aframe.url, text: 'GitHub', slug: 'github', title: 'A-Frame Project Repository'},
-  {url: 'https://discord.com/invite/tGYjkYr', text: 'Discord', slug: 'slug', title: 'A-Frame Discord Channel'},
+  {url: 'community/#discord', text: 'Discord', slug: 'slug', title: 'A-Frame Discord Channel'},
   {url: 'https://stackoverflow.com/questions/ask/?tags=aframe', text: 'Ask a Question'}
 ];
 links = links.map(function (link) {


### PR DESCRIPTION
I was told on Slack the current link doesn't work. I created a new non expiring invite link.

@dmarcos you should modify https://supermedium.com/discord to point to https://discord.gg/NPgArtG3Qz
that link is used in aframe and moonrider repositories for example.