### PR TITLE
Fix the npm link to really search for aframe-component tag

### DIFF
--- a/src/community/index.md
+++ b/src/community/index.md
@@ -83,7 +83,7 @@ directly!
 ## Ecosystem
 
 - [A Week of A-Frame](https://aframe.io/blog) - Weekly series featuring fresh content from the community.
-- [A-Frame Components](https://www.npmjs.com/search?q=aframe-component&page=1&ranking=optimal) - Packages in the NPM repository tagged `aframe-component`.  Most A-Frame components can be included using [unpkg](https://unpkg.com/) and a script tag. Many can also be included using the NPM tool.  Read the documentation for the individual package.
+- [A-Frame Components](https://www.npmjs.com/search?q=keywords:aframe-component) - Packages in the NPM repository tagged `aframe-component`.  Most A-Frame components can be included using [unpkg](https://unpkg.com/) and a script tag. Many can also be included using the NPM tool.  Read the documentation for the individual package.
 
 ## Discord
 


### PR DESCRIPTION
Fix the npm link to really search for aframe-component tag.
Previous link was searching for "aframe-component" that is actually equivalent of "aframe" or "component"  so you had packages in the results that weren't related to aframe at all.